### PR TITLE
add chardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ebooklib
 bs4
 python-docx
 mobi
+chardet


### PR DESCRIPTION
Resolve the following error message:
```
Traceback (most recent call last):
  File "~/ebook-GPT-translator/text_translation.py", line 114, in <module>
    import chardet
ModuleNotFoundError: No module named 'chardet'
```