### PR TITLE
应该实现了设置API_URL代理功能

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -99,6 +99,7 @@ python text_translation.py example.txt
 
 ## 特点
 - 代码从 settings.cfg 文件中读取 OpenAI API 密钥、目标语言和其他选项。
+- 该代码可以在配置文件中设置OpenAI API 代理。
 - 该代码分别使用 pdfminer 和 ebooklib 库将 PDF、DOCX 和 EPUB 文件转换为文本。
 - 该代码提供了一个选项来输出双语文本。
 - 代码提供了一个进度条来显示PDF/EPUB到文本转换和翻译的进度
@@ -109,6 +110,7 @@ python text_translation.py example.txt
 `settings.cfg` 文件包含几个可用于配置脚本行为的选项：
 
 - `openai-apikey`：您的 OpenAI API 的API Key
+- `openai-proxy`：OpenAI API 代理，如 `https://api.openai-proxy.com`，你可以在 [OpenAI API 代理](https://www.openai-proxy.com/) 看到一些用法与说明，如果你担心自己的API Key安全问题，可以查看 [Ice-Hazymoon/openai-scf-proxy](https://github.com/Ice-Hazymoon/openai-scf-proxy) 等反向代理API的项目自行搭建。
 - `prompt`: 你可以更改缺省的Chinese到"en", "zh-cn", "ja", "繁体中文","文言文", or "红楼梦风格的半文言文" etc，或用你常用的prompt定制。
 ![文言文](https://user-images.githubusercontent.com/40444824/223943798-4faf91a0-05ec-4a4e-9731-ba80bc9845c2.png)
 

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -2,6 +2,9 @@
 #API key for OpenAI API
 openai-apikey = sk-
 
+#API Proxy Url, e.g. https://api.openai-proxy.com
+openai-proxy =
+
 #Target language for translation, e.g. "en", "zh-cn", "ja",or "繁体中文","文言文"
 # target-language setting is deprecated, please use prompt setting instead
 

--- a/text_translation.py
+++ b/text_translation.py
@@ -131,6 +131,7 @@ openai_apikey = config.get('option', 'openai-apikey')
 prompt = config.get('option', 'prompt')
 bilingual_output = config.get('option', 'bilingual-output')
 language_code = config.get('option', 'langcode')
+api_proxy=config.get('option', 'openai-proxy')
 # Get startpage and endpage as integers with default values
 startpage = config.getint('option', 'startpage', fallback=1)
 endpage = config.getint('option', 'endpage', fallback=-1)
@@ -142,6 +143,14 @@ case_matching = config.get('option', 'case-matching')
 # 设置openai的API密钥
 openai.api_key = openai_apikey
 import argparse
+
+# 如果配置文件有写，就设置api代理
+if len(api_proxy) == 0:
+    print("未检测到OpenAI API 代理，当前使用api地址为: " + openai.api_base)
+else:
+    api_proxy_url = api_proxy + "/v1"
+    openai.api_base = os.environ.get("OPENAI_API_BASE", api_proxy_url)
+    print("正在使用OpenAI API 代理，代理地址为: "+openai.api_base)
 
 # 创建参数解析器
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
https://github.com/jesselau76/ebook-GPT-translator/issues/20
也就是这个issue，看了下依赖的包，其实改一个变量就可以了

修改openai依赖路径下 `__init__.py` 第37行的`api_base`变量即可

依赖中的代码如下
`api_base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")`