### PR TITLE
fix: Update OpenAI model version in README and text_translation.py

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -2,7 +2,7 @@
 
 [En](https://github.com/jesselau76/ebook-GPT-translator/blob/main/README.md) | [中文说明](https://github.com/jesselau76/ebook-GPT-translator/blob/main/README-zh.md)
 
-该工具旨在帮助用户将文本从一种格式转换为另一种格式，以及使用 OpenAI API (model=`gpt-3.5-turbo`) 将其翻译成另一种语言。 目前支持PDF、DOCX、MOBI和EPUB文件格式转换翻译成EPUB文件及文本文件，可以将文字翻译成多种语言。
+该工具旨在帮助用户将文本从一种格式转换为另一种格式，以及使用 OpenAI API (model=`gpt-3.5-turbo-16k`) 将其翻译成另一种语言。 目前支持PDF、DOCX、MOBI和EPUB文件格式转换翻译成EPUB文件及文本文件，可以将文字翻译成多种语言。
 
 注：
 - PDF、DOCX及MOBI文件只处理其中文本部分，图形部分不会出现在结果文件中。

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ebook-GPT-translator: Enjoy reading with your favorite style.
 [En](https://github.com/jesselau76/ebook-GPT-translator/blob/main/README.md) | [中文说明](https://github.com/jesselau76/ebook-GPT-translator/blob/main/README-zh.md)
 
-This tool is designed to help users convert text from one format to another, as well as translate it into a different language using the OpenAI API (model="gpt-3.5-turbo"). It currently supports converting and translating PDF, DOCX, EPUB, and MOBI file formats into EPUB and text files and can translate text into multiple languages.
+This tool is designed to help users convert text from one format to another, as well as translate it into a different language using the OpenAI API (model="gpt-3.5-turbo-16k"). It currently supports converting and translating PDF, DOCX, EPUB, and MOBI file formats into EPUB and text files and can translate text into multiple languages.
 
 Notes:
 

--- a/text_translation.py
+++ b/text_translation.py
@@ -149,7 +149,7 @@ key_array = openai_apikey.split(',')
 def random_api_key():
     return random.choice(key_array)
 
-def create_chat_completion(prompt, text, model="gpt-3.5-turbo", **kwargs):
+def create_chat_completion(prompt, text, model="gpt-3.5-turbo-16k", **kwargs):
     openai.api_key = random_api_key()
     return openai.ChatCompletion.create(
         model=model,
@@ -274,7 +274,7 @@ def convert_pdf_to_text(pdf_filename, start_page=1, end_page=-1):
     return text
 
 
-# 将文本分成不大于1024字符的短文本list
+# 将文本分成不大于1024*4字符的短文本list
 def split_text(text):
     sentence_list = re.findall(r'.+?[。！？!?.]', text)
 
@@ -284,10 +284,10 @@ def split_text(text):
     short_text = ""
     # 遍历句子列表
     for s in sentence_list:
-        # 如果当前短文本加上新的句子长度不大于1024，则将新的句子加入当前短文本
-        if len(short_text + s) <= 1024:
+        # 如果当前短文本加上新的句子长度不大于1024*4，则将新的句子加入当前短文本
+        if len(short_text + s) <= 1024*4:
             short_text += s
-        # 如果当前短文本加上新的句子长度大于1024，则将当前短文本加入短文本列表，并重置当前短文本为新的句子
+        # 如果当前短文本加上新的句子长度大于1024*4，则将当前短文本加入短文本列表，并重置当前短文本为新的句子
         else:
             short_text_list.append(short_text)
             short_text = s
@@ -453,7 +453,7 @@ if filename.endswith('.epub'):
             if args.tlist:
                 text = text_replace(text, transliteration_list_file, case_matching)
 
-            # 将文本分成不大于1024字符的短文本list
+            # 将文本分成不大于1024*4字符的短文本list
             short_text_list = split_text(text)
             if args.test:
                 short_text_list = short_text_list[:3]
@@ -501,7 +501,7 @@ else:
     if args.tlist:
         text = text_replace(text, transliteration_list_file, case_matching)
 
-    # 将文本分成不大于1024字符的短文本list
+    # 将文本分成不大于1024*4字符的短文本list
     short_text_list = split_text(text)
     if args.test:
         short_text_list = short_text_list[:3]


### PR DESCRIPTION
Update the OpenAI model version from gpt-3.5-turbo to gpt-3.5-turbo-16k in the README.md and text_translation.py files.

这个更改的原因是，目的既然是翻译一本书，那么自然翻译的越快越好，现在既然16k的模型已经开放了，那就直接使用好了，上下文是原来的 4 倍，~~也就意味着速度是原来的 4 倍~~，好处似乎只有上下文变成了 4 倍，可能获得更好的翻译结果吧，速度是不会变的