### PR TITLE
update create_chat_completion, in order to support new version of ope…

### DIFF
--- a/text_translation.py
+++ b/text_translation.py
@@ -150,8 +150,8 @@ def random_api_key():
     return random.choice(key_array)
 
 def create_chat_completion(prompt, text, model="gpt-3.5-turbo", **kwargs):
-    openai.api_key = random_api_key()
-    return openai.ChatCompletion.create(
+    client = openai.Client(api_key=random_api_key())
+    return client.chat.completions.create(
         model=model,
         messages=[
             {


### PR DESCRIPTION
The new version of openAI library (>=1.0.0) no longer supports the following syntax:
```python
openai.ChatCompletion.create(
  # ...
)
```

I rewrote it as:
```python
client = openai.Client(api_key=random_api_key())
return client.chat.completions.create(
    # ...
)
```

Reference:
https://github.com/openai/openai-python/blob/main/api.md#completions-1